### PR TITLE
scj: scope size not set in constructor for StorageParameters

### DIFF
--- a/java/target/src/rtapi/javax/safetycritical/StorageParameters.java
+++ b/java/target/src/rtapi/javax/safetycritical/StorageParameters.java
@@ -50,7 +50,7 @@ public class StorageParameters {
 
 	@SCJAllowed
 	public StorageParameters(long totalBackingStore, long[] sizes) {
-		this.totalBackingStore = totalBackingStore;
+		this(totalBackingStore, sizes, 0, 0);
 	}
 
 	


### PR DESCRIPTION
Scope size not set when using constructor with two arguments, resulting in a scope size of zero.
Therefore gives immediate out of memory exception when allocating in handlers.
