### PR TITLE
Changed datatype for scmo.

### DIFF
--- a/vhdl/simpcon/sc2ahbsl.vhd
+++ b/vhdl/simpcon/sc2ahbsl.vhd
@@ -50,7 +50,7 @@ port (
 	clk, reset	: in std_logic;
 
 --	SimpCon memory interface
-	scmo		: in sc_mem_out_type;
+	scmo		: in sc_out_type;
 	scmi		: out sc_in_type;
 
 -- AMBA slave interface


### PR DESCRIPTION
Data type sc_mem_out_type is nowhere defined. Changing it to sc_out_type; same as in file jop_amba.vhd
