### PR TITLE
Removed illegal generic maps

### DIFF
--- a/vhdl/memory/sc_dram16.vhd
+++ b/vhdl/memory/sc_dram16.vhd
@@ -6,7 +6,7 @@ use ieee.numeric_std.all;
 use work.sc_pack.all;
 use work.dram_pack.all;
 
-entity sc_mem_if is
+entity sc_dram16 is
 --  generic (addr_bits : integer);
 
   port (
@@ -23,9 +23,9 @@ entity sc_mem_if is
     dram_data : inout dram_data_type
 
     );
-end sc_mem_if;
+end sc_dram16;
 
-architecture rtl of sc_mem_if is
+architecture rtl of sc_dram16 is
 
   signal zeros : std_logic_vector(31 downto 0);
 -------------------------------------------------------------------------------

--- a/vhdl/memory/sc_sram16.vhd
+++ b/vhdl/memory/sc_sram16.vhd
@@ -51,7 +51,7 @@ use ieee.numeric_std.all;
 use work.jop_types.all;
 use work.sc_pack.all;
 
-entity sc_mem_if is
+entity sc_sram16 is
 generic (ram_ws : integer; addr_bits : integer);
 
 port (
@@ -75,9 +75,9 @@ port (
 	ram_nwe		: out std_logic
 
 );
-end sc_mem_if;
+end sc_sram16;
 
-architecture rtl of sc_mem_if is
+architecture rtl of sc_sram16 is
 
 --
 --	signals for mem interface

--- a/vhdl/memory/sc_sram32.vhd
+++ b/vhdl/memory/sc_sram32.vhd
@@ -46,7 +46,7 @@ use ieee.numeric_std.all;
 use work.jop_types.all;
 use work.sc_pack.all;
 
-entity sc_mem_if is
+entity sc_sram32 is
 generic (ram_ws : integer; addr_bits : integer);
 
 port (
@@ -70,9 +70,9 @@ port (
 	ram_nwe		: out std_logic
 
 );
-end sc_mem_if;
+end sc_sram32;
 
-architecture rtl of sc_mem_if is
+architecture rtl of sc_sram32 is
 
 --
 --	signals for mem interface

--- a/vhdl/memory/sc_sram32_flash.vhd
+++ b/vhdl/memory/sc_sram32_flash.vhd
@@ -55,7 +55,7 @@ use ieee.numeric_std.all;
 use work.jop_types.all;
 use work.sc_pack.all;
 
-entity sc_mem_if is
+entity sc_sram32_flash is
 generic (ram_ws : integer; rom_ws : integer);
 
 port (
@@ -90,9 +90,9 @@ port (
 	fl_rdy	: in std_logic
 
 );
-end sc_mem_if;
+end sc_sram32_flash;
 
-architecture rtl of sc_mem_if is
+architecture rtl of sc_sram32_flash is
 
 --
 --	signals for mem interface

--- a/vhdl/memory/sc_sram8.vhd
+++ b/vhdl/memory/sc_sram8.vhd
@@ -51,7 +51,7 @@ use ieee.numeric_std.all;
 use work.jop_types.all;
 use work.sc_pack.all;
 
-entity sc_mem_if is
+entity sc_sram8 is
 generic (ram_ws : integer; addr_bits : integer);
 
 port (
@@ -75,9 +75,9 @@ port (
 	ram_nwe		: out std_logic
 
 );
-end sc_mem_if;
+end sc_sram8;
 
-architecture rtl of sc_mem_if is
+architecture rtl of sc_sram8 is
 
 --
 --	signals for mem interface

--- a/vhdl/memory/sc_ssram32.vhd
+++ b/vhdl/memory/sc_ssram32.vhd
@@ -47,7 +47,7 @@ use ieee.numeric_std.all;
 use work.jop_types.all;
 use work.sc_pack.all;
 
-entity sc_mem_if is
+entity sc_ssram32 is
 generic (ram_ws : integer; addr_bits : integer);
 
 port (
@@ -74,9 +74,9 @@ port (
 	ram_nwe		: out std_logic
 
 );
-end sc_mem_if;
+end sc_ssram32;
 
-architecture rtl of sc_mem_if is
+architecture rtl of sc_ssram32 is
 
 --
 --	signals for mem interface

--- a/vhdl/paper/csp/jopde2-70csp.vhd
+++ b/vhdl/paper/csp/jopde2-70csp.vhd
@@ -346,7 +346,7 @@ end process;
 		);
 	end generate;
 
-	scm: entity work.sc_mem_if
+	scm: entity work.sc_ssram32
 		generic map (
 			ram_ws => ram_cnt-1,
 			addr_bits => 19

--- a/vhdl/paper/csp/jopmulcsp.vhd
+++ b/vhdl/paper/csp/jopmulcsp.vhd
@@ -289,7 +289,7 @@ end process;
 			-- sync_out_array(1)
 			);
 
-	scm: entity work.sc_mem_if
+	scm: entity work.sc_sram32_flash
 		generic map (
 			ram_ws => ram_cnt-1,
 			rom_ws => rom_cnt-1

--- a/vhdl/paper/csp/jopmulcsp2rings.vhd
+++ b/vhdl/paper/csp/jopmulcsp2rings.vhd
@@ -329,7 +329,7 @@ end process;
 			-- sync_out_array(1)
 			);
 
-	scm: entity work.sc_mem_if
+	scm: entity work.sc_sram32_flash
 		generic map (
 			ram_ws => ram_cnt-1,
 			rom_ws => rom_cnt-1

--- a/vhdl/paper/nexys2_csp/jopmulcsp.vhd
+++ b/vhdl/paper/nexys2_csp/jopmulcsp.vhd
@@ -331,7 +331,7 @@ end process;
 			-- sync_out_array(1)
 			);
 
-	scm: entity work.sc_mem_if
+	scm: entity work.sc_sram16
 		generic map (
 			ram_ws => ram_cnt-1,
   -- 		rom_ws => rom_cnt-1

--- a/vhdl/paper/nexys2_csp/jopmulcsp2rings.vhd
+++ b/vhdl/paper/nexys2_csp/jopmulcsp2rings.vhd
@@ -374,7 +374,7 @@ end process;
 			-- sync_out_array(1)
 			);
 
-	scm: entity work.sc_mem_if
+	scm: entity work.sc_sram16
 		generic map (
 			ram_ws => ram_cnt-1,
   -- 		rom_ws => rom_cnt-1

--- a/vhdl/rttm/sim/mem_no_arbiter.vhd
+++ b/vhdl/rttm/sim/mem_no_arbiter.vhd
@@ -72,7 +72,7 @@ signal fl_d	: std_logic_vector(7 downto 0);
 
 begin
 
-	mem_if: entity work.sc_mem_if(rtl)
+	mem_if: entity work.sc_sram32_flash(rtl)
 	generic map (
 		ram_ws => ram_cnt-1,
 		rom_ws => rom_cnt-1

--- a/vhdl/simpcon/sc_arbiter_fair.vhd
+++ b/vhdl/simpcon/sc_arbiter_fair.vhd
@@ -49,10 +49,7 @@ use work.jop_types.all;
 entity arbiter is
 generic(
 		addr_bits : integer;
-		cpu_cnt	: integer; -- number of masters for the arbiter
-		write_gap : integer; -- dummy to be compatible with TDMA arbiter
-		read_gap  : integer;
-		slot_length : integer
+		cpu_cnt	: integer -- number of masters for the arbiter
 		);
 port (
 			clk, reset	: in std_logic;			
@@ -64,7 +61,7 @@ port (
 end arbiter;
 
 
-architecture rtl of arbiter is
+architecture rtl_fair of arbiter is
 
 -- stores the signals in a register of each master
 
@@ -443,4 +440,4 @@ gen_rdy_cnt: for i in 0 to cpu_cnt-1 generate
 	end process;
 end generate;
 
-end rtl;
+end rtl_fair;

--- a/vhdl/simpcon/sc_arbiter_fixedpr.vhd
+++ b/vhdl/simpcon/sc_arbiter_fixedpr.vhd
@@ -37,25 +37,9 @@ use ieee.numeric_std.all;
 use work.sc_pack.all;
 use work.sc_arbiter_pack.all;
 
-entity arbiter is
-generic(
-		addr_bits : integer;
-		cpu_cnt	: integer; -- number of masters for the arbiter
-		write_gap : integer; -- dummy to be compatible with TDMA arbiter
-		read_gap  : integer;
-		slot_length : integer
-		);
-port (
-			clk, reset	: in std_logic;			
-			arb_out			: in arb_out_type(0 to cpu_cnt-1);
-			arb_in			: out arb_in_type(0 to cpu_cnt-1);
-			mem_out			: out sc_out_type;
-			mem_in			: in sc_in_type
-);
-end arbiter;
+-- entity interface compatible with arbiter_fair
 
-
-architecture rtl of arbiter is
+architecture rtl_fixedpr of arbiter is
 
 -- signals for the input register of each master
 
@@ -447,4 +431,4 @@ gen_rdy_cnt: for i in 0 to cpu_cnt-1 generate
 	end process;
 end generate;
 
-end rtl;
+end rtl_fixedpr;

--- a/vhdl/simpcon/sc_arbiter_fixedpr_int.vhd
+++ b/vhdl/simpcon/sc_arbiter_fixedpr_int.vhd
@@ -37,25 +37,9 @@ use ieee.numeric_std.all;
 use work.sc_pack.all;
 use work.sc_arbiter_pack.all;
 
-entity arbiter is
-generic(
-		addr_bits : integer;
-		cpu_cnt	: integer; -- number of masters for the arbiter
-		write_gap : integer; -- dummy to be compatible with TDMA arbiter
-		read_gap  : integer;
-		slot_length : integer
-		);
-port (
-			clk, reset	: in std_logic;			
-			arb_out			: in arb_out_type(0 to cpu_cnt-1);
-			arb_in			: out arb_in_type(0 to cpu_cnt-1);
-			mem_out			: out sc_out_type;
-			mem_in			: in sc_in_type
-);
-end arbiter;
+-- entity interface compatible with arbiter_fair
 
-
-architecture rtl of arbiter is
+architecture rtl_fixedpr_int of arbiter is
 
 -- signals for the input register of each master
 
@@ -481,4 +465,4 @@ gen_rdy_cnt: for i in 0 to cpu_cnt-1 generate
 	end process;
 end generate;
 
-end rtl;
+end rtl_fixedpr_int;

--- a/vhdl/simpcon/sc_arbiter_rr.vhd
+++ b/vhdl/simpcon/sc_arbiter_rr.vhd
@@ -51,25 +51,9 @@ use work.sc_pack.all;
 use work.sc_arbiter_pack.all;
 use work.jop_types.all;
 
-entity arbiter is
-	generic(
-		addr_bits : integer;
-		cpu_cnt	: integer; -- number of masters for the arbiter
-		write_gap : integer; -- dummy to be compatible with TDMA arbiter
-		read_gap  : integer;
-		slot_length : integer
-		);
-	port (
-		clk, reset	: in std_logic;			
-		arb_out			: in arb_out_type(0 to CPU_CNT-1);
-		arb_in			: out arb_in_type(0 to CPU_CNT-1);
-		mem_out			: out sc_out_type;
-		mem_in			: in sc_in_type
-		);
-end arbiter;
+-- entity interface compatible with arbiter_fair
 
-
-architecture rtl of arbiter is
+architecture rtl_rr of arbiter is
 
 -- stores the signals in a register of each master
 	signal reg_out, next_reg_out : arb_out_type(0 to CPU_CNT-1);
@@ -260,4 +244,4 @@ begin
 		end loop;  -- i		
 	end process mux;
 
-end rtl;
+end rtl_rr;

--- a/vhdl/simpcon/sc_arbiter_rttm_tdma.vhd
+++ b/vhdl/simpcon/sc_arbiter_rttm_tdma.vhd
@@ -59,7 +59,7 @@ use work.sc_pack.all;
 use work.sc_arbiter_pack.all;
 use work.jop_types.all;
 
-entity arbiter is
+entity arbiter_rttm_tdm is
 generic(
 			addr_bits : integer;
 			cpu_cnt	: integer);		-- number of masters for the arbiter
@@ -74,10 +74,10 @@ port (
 			tm_in_transaction : in std_logic_vector(0 to cpu_cnt-1);
 			tm_broadcast	: out tm_broadcast_type
 );
-end arbiter;
+end arbiter_rttm_tdm;
 
 
-architecture rtl of arbiter is
+architecture rtl of arbiter_rttm_tdm is
 
 -- stores the signals in a register of each master
 

--- a/vhdl/simpcon/sc_arbiter_tdma.vhd
+++ b/vhdl/simpcon/sc_arbiter_tdma.vhd
@@ -65,7 +65,7 @@ use work.jop_types.all;
 --               minimal slot_length <= 3;
 -- Nexys2: 24, 24, 32 (number assigned by Flavius)
 
-entity arbiter is
+entity arbiter_tdma is
 	generic(
 		addr_bits : integer;
 		cpu_cnt	: integer;
@@ -80,10 +80,10 @@ entity arbiter is
 		mem_out			: out sc_out_type;
 		mem_in			: in sc_in_type
 		);
-end arbiter;
+end arbiter_tdma;
 
 
-architecture rtl of arbiter is
+architecture rtl of arbiter_tdma is
 
 -- stores the signals in a register of each master
 	signal reg_out, next_reg_out : arb_out_type(0 to cpu_cnt-1);

--- a/vhdl/top/jop_256x16.vhd
+++ b/vhdl/top/jop_256x16.vhd
@@ -203,8 +203,8 @@ end process;
 			-- remove the comment for RAM access counting
 			-- ram_cnt => ram_count
 		);
-
-	scm: entity work.sc_mem_if
+	
+	scm: entity work.sc_sram16
 		generic map (
 			ram_ws => ram_cnt-1,
 			addr_bits => 18

--- a/vhdl/top/jop_512x32.vhd
+++ b/vhdl/top/jop_512x32.vhd
@@ -239,7 +239,7 @@ end process;
 
 		);
 
-	scm: entity work.sc_mem_if
+	scm: entity work.sc_ssram32
 		generic map (
 			ram_ws => ram_cnt-1,
 			addr_bits => 19			-- edit

--- a/vhdl/top/jop_512x32_cache.vhd
+++ b/vhdl/top/jop_512x32_cache.vhd
@@ -244,7 +244,7 @@ end process;
 			mem_out => sc_mem_out
 		);
 
-scm: entity work.sc_mem_if
+scm: entity work.sc_ssram32
 		generic map (
 			ram_ws => ram_cnt-1,
 			addr_bits => 19			-- edit

--- a/vhdl/top/jop_de2-70iic.vhd
+++ b/vhdl/top/jop_de2-70iic.vhd
@@ -236,7 +236,7 @@ end process;
 
 		);
 
-	scm: entity work.sc_mem_if
+	scm: entity work.sc_ssram32
 		generic map (
 			ram_ws => ram_cnt-1,
 			addr_bits => 19			-- edit

--- a/vhdl/top/jop_de2-70reprap.vhd
+++ b/vhdl/top/jop_de2-70reprap.vhd
@@ -246,7 +246,7 @@ end process;
 
 		);
 
-	scm: entity work.sc_mem_if
+	scm: entity work.sc_ssram32
 		generic map (
 			ram_ws => ram_cnt-1,
 			addr_bits => 19			-- edit

--- a/vhdl/top/jop_de2-70rttm.vhd
+++ b/vhdl/top/jop_de2-70rttm.vhd
@@ -337,7 +337,7 @@ end process;
 	end process hold_tm_broadcast;
 
 
-	scm: entity work.sc_mem_if
+	scm: entity work.sc_ssram32
 		generic map (
 			ram_ws => ram_cnt-1,
 			addr_bits => tm_addr_width			-- edit

--- a/vhdl/top/jop_de2-70rttm.vhd
+++ b/vhdl/top/jop_de2-70rttm.vhd
@@ -282,7 +282,7 @@ end process;
 		commit_token_grant => commit_token_grant
 		);
 
-	arbiter : entity work.arbiter
+	arbiter : entity work.arbiter_rttm_tdm
 		generic map(
 			addr_bits => SC_ADDR_SIZE,
 			cpu_cnt	=> cpu_cnt)

--- a/vhdl/top/jop_de2-70vga.vhd
+++ b/vhdl/top/jop_de2-70vga.vhd
@@ -379,7 +379,7 @@ my_crt_pll : crt_pll
 			-- ram_cnt => ram_count
 		);
 		
-	scm: entity work.sc_mem_if
+	scm: entity work.sc_ssram32
 		generic map (
 			ram_ws => ram_cnt-1,
 			addr_bits => 19			-- edit

--- a/vhdl/top/jop_dram.vhd
+++ b/vhdl/top/jop_dram.vhd
@@ -180,7 +180,7 @@ begin
               b         => open
               );
 
-  scm: entity work.sc_mem_if
+  scm: entity work.sc_dram16
     port map (
       clk        => clk,                -- [in]
       reset      => int_res,              -- [in]

--- a/vhdl/top/jop_iic.vhd
+++ b/vhdl/top/jop_iic.vhd
@@ -234,7 +234,7 @@ end process;
 			scl => scl
 		);
 
-	scm: entity work.sc_mem_if
+	scm: entity work.sc_sram32_flash
 		generic map (
 			ram_ws => ram_cnt-1,
 			rom_ws => rom_cnt-1

--- a/vhdl/top/jop_jpd_cyc12.vhd
+++ b/vhdl/top/jop_jpd_cyc12.vhd
@@ -362,7 +362,6 @@ end process;
 
 	-- HW methods
     cp1 : entity work.mac_coprocessor 
-        generic map ( id => x"01", version => x"1234" )
         port map (
                 clk => clk_int,
                 reset => int_res,
@@ -379,7 +378,6 @@ end process;
                 cc_in_rdy => cc_2_rdy
             );
     cp2 : entity work.mac_coprocessor 
-        generic map ( id => x"02", version => x"abcd" )
         port map (
                 clk => clk_int,
                 reset => int_res,

--- a/vhdl/top/jop_jpd_cyc12.vhd
+++ b/vhdl/top/jop_jpd_cyc12.vhd
@@ -258,7 +258,7 @@ end process;
 			-- sync_out_array(1)
 			);
 
-	scm: entity work.sc_mem_if
+	scm: entity work.sc_sram32_flash
 		generic map (
 			ram_ws => ram_cnt-1,
 			rom_ws => rom_cnt-1

--- a/vhdl/top/jop_ml401.vhd
+++ b/vhdl/top/jop_ml401.vhd
@@ -240,7 +240,7 @@ end process;
 			b => open
 		);
 
-	scm: entity work.sc_mem_if
+	scm: entity work.sc_sram16
 		generic map (
 			ram_ws => ram_cnt-1,
 			addr_bits => 18

--- a/vhdl/top/jop_ml50x.vhd
+++ b/vhdl/top/jop_ml50x.vhd
@@ -220,7 +220,7 @@ end process;
 			b => open
 		);
 
-	scm: entity work.sc_mem_if
+	scm: entity work.sc_sram16
 		generic map (
 			ram_ws => ram_cnt-1,
 			addr_bits => 18

--- a/vhdl/top/jop_ml50x_iic.vhd
+++ b/vhdl/top/jop_ml50x_iic.vhd
@@ -300,7 +300,7 @@ end process;
 			scl => scl
 		);
 
-	scm: entity work.sc_mem_if
+	scm: entity work.sc_sram16
 		generic map (
 			ram_ws => ram_cnt-1,
 			addr_bits => 18

--- a/vhdl/top/jop_nexys2.vhd
+++ b/vhdl/top/jop_nexys2.vhd
@@ -178,7 +178,7 @@ end process;
 			b => open
 		);
 
-	scm: entity work.sc_mem_if
+	scm: entity work.sc_sram16
 		generic map (
 			ram_ws => ram_cnt-1,
 			addr_bits => 21

--- a/vhdl/top/jop_xs3.vhd
+++ b/vhdl/top/jop_xs3.vhd
@@ -212,7 +212,7 @@ end process;
 			b => open
 		);
 
-	scm: entity work.sc_mem_if
+	scm: entity work.sc_sram16
 		generic map (
 			ram_ws => ram_cnt-1,
 			addr_bits => 18

--- a/vhdl/top/jopcyc.vhd
+++ b/vhdl/top/jopcyc.vhd
@@ -239,7 +239,7 @@ end process;
 			b => io_b
 		);
 
-	scm: entity work.sc_mem_if
+	scm: entity work.sc_sram32_flash
 		generic map (
 			ram_ws => ram_cnt-1,
 			rom_ws => rom_cnt-1

--- a/vhdl/top/jopcyc12.vhd
+++ b/vhdl/top/jopcyc12.vhd
@@ -239,7 +239,7 @@ end process;
 			-- ram_cnt => ram_count
 		);
 
-	scm: entity work.sc_mem_if
+	scm: entity work.sc_sram32_flash
 		generic map (
 			ram_ws => ram_cnt-1,
 			rom_ws => rom_cnt-1

--- a/vhdl/top/jopcyc12_cache.vhd
+++ b/vhdl/top/jopcyc12_cache.vhd
@@ -256,7 +256,7 @@ end process;
 		);
 		
 
-	scm: entity work.sc_mem_if
+	scm: entity work.sc_sram32_flash
 		generic map (
 			ram_ws => ram_cnt-1,
 			rom_ws => rom_cnt-1

--- a/vhdl/top/jopmul.vhd
+++ b/vhdl/top/jopmul.vhd
@@ -259,7 +259,7 @@ end process;
 			-- sync_out_array(1)
 			);
 
-	scm: entity work.sc_mem_if
+	scm: entity work.sc_sram32_flash
 		generic map (
 			ram_ws => ram_cnt-1,
 			rom_ws => rom_cnt-1

--- a/vhdl/top/jopmul.vhd
+++ b/vhdl/top/jopmul.vhd
@@ -243,7 +243,7 @@ end process;
 				irq_out(i), exc_req(i));
 	end generate;
 			
-	arbiter: entity work.arbiter
+	arbiter: entity work.arbiter_tdma
 		generic map(
 			addr_bits => SC_ADDR_SIZE,
 			cpu_cnt => cpu_cnt,

--- a/vhdl/top/jopmul_256x16.vhd
+++ b/vhdl/top/jopmul_256x16.vhd
@@ -271,8 +271,8 @@ end process;
 			-- ram_count => ram_count
 		);
 	end generate;
-
-	scm: entity work.sc_mem_if
+	
+	scm: entity work.sc_sram16
 		generic map (
 			ram_ws => ram_cnt-1,
 			addr_bits => 18

--- a/vhdl/top/jopmul_256x16_cache.vhd
+++ b/vhdl/top/jopmul_256x16_cache.vhd
@@ -283,7 +283,7 @@ end process;
 		);
 	end generate;
 
-	scm: entity work.sc_mem_if
+	scm: entity work.sc_sram16
 		generic map (
 			ram_ws => ram_cnt-1,
 			addr_bits => 18

--- a/vhdl/top/jopmul_512x32.vhd
+++ b/vhdl/top/jopmul_512x32.vhd
@@ -237,7 +237,7 @@ end process;
 				irq_in(i), irq_out(i), exc_req(i));
 	end generate;
 	
-	arbiter: entity work.arbiter
+	arbiter: entity work.arbiter_tdma
 		generic map(
 			addr_bits => SC_ADDR_SIZE,
 			cpu_cnt => cpu_cnt,

--- a/vhdl/top/jopmul_512x32.vhd
+++ b/vhdl/top/jopmul_512x32.vhd
@@ -309,7 +309,7 @@ end process;
 		);
 	end generate;
 
-	scm: entity work.sc_mem_if
+	scm: entity work.sc_ssram32
 		generic map (
 			ram_ws => ram_cnt-1,
 			addr_bits => 19

--- a/vhdl/top/jopmul_512x32_cache.vhd
+++ b/vhdl/top/jopmul_512x32_cache.vhd
@@ -311,7 +311,7 @@ end process;
 		);
 	end generate;
 
-	scm: entity work.sc_mem_if
+	scm: entity work.sc_ssram32
 		generic map (
 			ram_ws => ram_cnt-1,
 			addr_bits => 19

--- a/vhdl/top/joprttm.vhd
+++ b/vhdl/top/joprttm.vhd
@@ -303,7 +303,7 @@ end process;
 		commit_token_grant => commit_token_grant
 		);
 			
-	arbiter: entity work.arbiter
+	arbiter: entity work.arbiter_rttm_tdm
 		generic map(
 			addr_bits => SC_ADDR_SIZE,
 			cpu_cnt => cpu_cnt

--- a/vhdl/top/joprttm.vhd
+++ b/vhdl/top/joprttm.vhd
@@ -355,7 +355,7 @@ end process;
 	end process hold_tm_broadcast;
 
 
-	scm: entity work.sc_mem_if
+	scm: entity work.sc_sram32_flash
 		generic map (
 			ram_ws => ram_cnt-1,
 			rom_ws => rom_cnt-1

--- a/vhdl/top/jopvga.vhd
+++ b/vhdl/top/jopvga.vhd
@@ -245,7 +245,7 @@ end process;
 			sc_arb_out, sc_arb_in,
 			sc_mem_out, sc_mem_in);
 
-	scm: entity work.sc_mem_if
+	scm: entity work.sc_sram32_flash
 		generic map (
 			ram_ws => ram_cnt-1,
 			rom_ws => rom_cnt-1


### PR DESCRIPTION
Entity mac_coprocessor does not have generics, so we cannot have a generic map here.
